### PR TITLE
Fix edxzip.py to create a package within python_lib.zip

### DIFF
--- a/edxzip.py
+++ b/edxzip.py
@@ -1,15 +1,26 @@
 import zipfile
 import os
+import re
+
+
+def addfile(source, ziph):
+    target = os.path.join('sketchresponse/', source)
+    print('Adding ' + target)
+    ziph.write(source, target)
 
 
 def zipdir(path, ziph):
     # ziph is zipfile handle
     for root, dirs, files in os.walk(path):
         for file in files:
-            ziph.write(os.path.join(root, file))
+            if re.fullmatch(r'.+\.py|LICENSE', file):
+                addfile(os.path.join(root, file), ziph)
+
 
 if __name__ == '__main__':
     zipf = zipfile.ZipFile('python_lib.zip', 'w', zipfile.ZIP_DEFLATED)
-    zipf.write('sketchresponse.py')
+    addfile('__init__.py', zipf)
+    addfile('sketchresponse.py', zipf)
+    addfile('LICENSE', zipf)
     zipdir('grader_lib/', zipf)
     zipf.close()


### PR DESCRIPTION
While upgrading to Python 3 (which handles imports differently) we accidentally broke the compatibility between our example grader scripts and our `edxzip.py` utility. This update causes `edxzip.py` to include sketchresponse as a package in `python_lib.zip`, as expected by the imports in the examples.

There are also minor updates to avoid zipping unnecessary files (anything except python source code and license files).