### PR TITLE
Is straight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ target/
 
 # front-end build
 static/sketch_tool_dist/
+
+# jupyter notebooks
+jupyter_notebook


### PR DESCRIPTION
[Sketch Response is_straight() comparison.pdf](https://github.com/SketchResponse/sketchresponse/files/7230596/Sketch.Response.is_straight.comparison.pdf)

Fixed is_straight to accept vertical lines and also to not accept vertical curves that are not functions (see pdf). I modified the is_straight_between() function to get points from the Bezier curves directly instead of interpolating. To check for straightness, I compare the arc length of the curve (calculated by summing the distances between points) to the distance between the endpoints of the curve.
