### PR TITLE
adds draggable attribute to toolbar icons so they don't move

### DIFF
--- a/sketch_tool/lib/toolbar.js
+++ b/sketch_tool/lib/toolbar.js
@@ -10,6 +10,7 @@ function renderIcon(id, src, alt) {
   return z('img.icon', {
     id,
     src: src || NULL_SRC,
+    draggable: 'false',
     alt,
   });
 }


### PR DESCRIPTION
Hi! I use a wacom tablet with SketchResponse. Sometimes when I click a toolbar button, the stylus ends up dragging the button image instead of registering a mouse down event.  